### PR TITLE
updated with the power of grayskull

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pystac" %}
-{% set version = "1.7.1" %}
-
+{% set version = "1.7.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pystac-{{ version }}.tar.gz
-  sha256: a01da05cb29d0eb995a11e32a6d15067f653ceb8c64f61f912ac99c7e9ff4f2e
+  sha256: 049e8ece607e872241e872fd1f84dab5a2003b36dcbab9a013542f96d1b6c95d
 
 build:
   number: 0


### PR DESCRIPTION
This version is shipping a module named `benchmarks` and I believe that is a mistake. I'll open an issue upstream.

xref.: https://github.com/stac-utils/pystac/issues/1085